### PR TITLE
Added a combinations iterator for a different order

### DIFF
--- a/combination_iterator.hpp
+++ b/combination_iterator.hpp
@@ -11,6 +11,8 @@
 #ifndef COMBINATION_ITERATOR_HPP
 #define COMBINATION_ITERATOR_HPP
 
+// This code was produced by Juho Lauri (euler314).
+
 #include <vector>
 #include <numeric>
 #include <cassert>
@@ -27,9 +29,9 @@ class combination_iterator
 	>
 {
 public:
-	combination_iterator() : end_(true), n_(0), size_(0), comb_() { }
+	combination_iterator() : end_(true), n_(0), k_(0), comb_() { }
 
-	explicit combination_iterator(T n, T k) : end_(false), n_(n), size_(k), comb_(k)
+	explicit combination_iterator(T n, T k) : end_(false), n_(n), k_(k), comb_(k)
 	{
 		assert(k != 0 && n_ > k);
 		std::iota(comb_.begin(), comb_.end(), 0);
@@ -41,20 +43,20 @@ private:
 
 	void increment()
 	{
-		std::int64_t j = size_ - 1;
+		std::int64_t j = k_ - 1;
 
-		for (const T end = n_ - size_; j >= 0 && comb_[j] >= end + j; --j) { }
+		for (const T end = n_ - k_; j >= 0 && comb_[j] >= end + j; --j) { }
 
 		if (j < 0)
 		{
-			assert(comb_.front() == n_ - size_);
+			assert(comb_.front() == n_ - k_);
 			end_ = true;
 			return;
 		}
 
 		++comb_[j];
 
-		for (const std::int64_t end = size_ - 1; j < end; ++j)
+		for (const std::int64_t end = k_ - 1; j < end; ++j)
 		{
 			comb_[j + 1] = comb_[j] + 1;
 		}
@@ -74,7 +76,65 @@ private:
 
 	bool end_;
 	const int n_;
-	const int size_;
+	const int k_;
+	std::vector<T> comb_;
+};
+
+
+template <typename T>
+class combination_iterator_maximin_order
+	: public boost::iterator_facade<
+	combination_iterator_maximin_order<T>,
+	const std::vector<T>&,
+	boost::forward_traversal_tag
+	>
+{
+public:
+	combination_iterator_maximin_order() : end_(true), n_(0), k_(0), comb_() { }
+
+	explicit combination_iterator_maximin_order(T n, T k) : end_(false), n_(n), k_(k), comb_(k)
+	{
+		assert(k != 0 && n_ > k);
+		std::iota(comb_.begin(), comb_.end(), 0);
+		assert(!end_);
+	}
+
+private:
+	friend class boost::iterator_core_access;
+
+	void increment()
+	{
+		//The following code was copied from the discreture library: http://github.com/mraggi/discreture
+		if (comb_.empty())
+			return;
+		T last = comb_.size()-1;
+		for (T i = 0; i < last; ++i)
+		{
+			if (comb_[i]+1 != comb_[i+1])
+			{
+				++comb_[i];
+				return;
+			} 
+			comb_[i] = i;
+		}
+		if (comb_[last]+1 == n_)
+			end_ = true;
+		++comb_[last];
+	}
+
+	bool equal(const combination_iterator_maximin_order& other) const
+	{
+		return end_ == other.end_;
+	}
+
+	const std::vector<T>& dereference() const
+	{
+		return comb_;
+	}
+
+	bool end_;
+	const int n_;
+	const int k_;
 	std::vector<T> comb_;
 };
 

--- a/combination_iterator.hpp
+++ b/combination_iterator.hpp
@@ -11,8 +11,6 @@
 #ifndef COMBINATION_ITERATOR_HPP
 #define COMBINATION_ITERATOR_HPP
 
-// This code was produced by Juho Lauri (euler314).
-
 #include <vector>
 #include <numeric>
 #include <cassert>

--- a/combination_iterator.hpp
+++ b/combination_iterator.hpp
@@ -29,9 +29,9 @@ class combination_iterator
 	>
 {
 public:
-	combination_iterator() : end_(true), n_(0), k_(0), comb_() { }
+	combination_iterator() : end_(true), n_(0), size_(0), comb_() { }
 
-	explicit combination_iterator(T n, T k) : end_(false), n_(n), k_(k), comb_(k)
+	explicit combination_iterator(T n, T k) : end_(false), n_(n), size_(k), comb_(k)
 	{
 		assert(k != 0 && n_ > k);
 		std::iota(comb_.begin(), comb_.end(), 0);
@@ -43,20 +43,20 @@ private:
 
 	void increment()
 	{
-		std::int64_t j = k_ - 1;
+		std::int64_t j = size_ - 1;
 
-		for (const T end = n_ - k_; j >= 0 && comb_[j] >= end + j; --j) { }
+		for (const T end = n_ - size_; j >= 0 && comb_[j] >= end + j; --j) { }
 
 		if (j < 0)
 		{
-			assert(comb_.front() == n_ - k_);
+			assert(comb_.front() == n_ - size_);
 			end_ = true;
 			return;
 		}
 
 		++comb_[j];
 
-		for (const std::int64_t end = k_ - 1; j < end; ++j)
+		for (const std::int64_t end = size_ - 1; j < end; ++j)
 		{
 			comb_[j + 1] = comb_[j] + 1;
 		}
@@ -76,7 +76,7 @@ private:
 
 	bool end_;
 	const int n_;
-	const int k_;
+	const int size_;
 	std::vector<T> comb_;
 };
 
@@ -90,9 +90,9 @@ class combination_iterator_maximin_order
 	>
 {
 public:
-	combination_iterator_maximin_order() : end_(true), n_(0), k_(0), comb_() { }
+	combination_iterator_maximin_order() : end_(true), n_(0), size_(0), comb_() { }
 
-	explicit combination_iterator_maximin_order(T n, T k) : end_(false), n_(n), k_(k), comb_(k)
+	explicit combination_iterator_maximin_order(T n, T k) : end_(false), n_(n), size_(k), comb_(k)
 	{
 		assert(k != 0 && n_ > k);
 		std::iota(comb_.begin(), comb_.end(), 0);
@@ -134,7 +134,7 @@ private:
 
 	bool end_;
 	const int n_;
-	const int k_;
+	const int size_;
 	std::vector<T> comb_;
 };
 


### PR DESCRIPTION
Copied from the discreture library (which I maintain, and includes combinations among other things). Instead of iterating combinations in lexicographic order, this one iterates in the following order:
0 1 2
0 1 3
0 2 3
1 2 3
0 1 4
0 2 4
1 2 4
0 3 4
1 3 4
2 3 4

Anyway, this is faster on my machine. This is the default iterating order in discreture.

Not sure about the name, though. I called it "maximin" order, because the maximum is minimum possible, but I don't know what other name to come up with.